### PR TITLE
Make provided base32 Encoding case insensitive

### DIFF
--- a/base32.go
+++ b/base32.go
@@ -24,6 +24,11 @@ type Encoding struct {
 	padChar   rune
 }
 
+// Alphabet returns the Base32 alphabet used
+func (enc *Encoding) Alphabet() string {
+	return enc.encode
+}
+
 const (
 	StdPadding rune = '='
 	NoPadding  rune = -1

--- a/base32.go
+++ b/base32.go
@@ -47,6 +47,36 @@ func NewEncoding(encoder string) *Encoding {
 	return e
 }
 
+// NewEncoding returns a new case insensitive Encoding defined by the
+// given alphabet, which must be a 32-byte string.
+func NewEncodingCI(encoder string) *Encoding {
+	e := new(Encoding)
+	e.padChar = StdPadding
+	e.encode = encoder
+	for i := 0; i < len(e.decodeMap); i++ {
+		e.decodeMap[i] = 0xFF
+	}
+	for i := 0; i < len(encoder); i++ {
+		e.decodeMap[asciiToLower(encoder[i])] = byte(i)
+		e.decodeMap[asciiToUpper(encoder[i])] = byte(i)
+	}
+	return e
+}
+
+func asciiToLower(c byte) byte {
+	if c >= 'A' && c <= 'Z' {
+		return c + 32
+	}
+	return c
+}
+
+func asciiToUpper(c byte) byte {
+	if c >= 'a' && c <= 'z' {
+		return c - 32
+	}
+	return c
+}
+
 // WithPadding creates a new encoding identical to enc except
 // with a specified padding character, or NoPadding to disable padding.
 func (enc Encoding) WithPadding(padding rune) *Encoding {
@@ -56,14 +86,14 @@ func (enc Encoding) WithPadding(padding rune) *Encoding {
 
 // StdEncoding is the standard base32 encoding, as defined in
 // RFC 4648.
-var StdEncoding = NewEncoding(encodeStd)
+var StdEncoding = NewEncodingCI(encodeStd)
 
 // HexEncoding is the ``Extended Hex Alphabet'' defined in RFC 4648.
 // It is typically used in DNS.
-var HexEncoding = NewEncoding(encodeHex)
+var HexEncoding = NewEncodingCI(encodeHex)
 
-var RawStdEncoding = NewEncoding(encodeStd).WithPadding(NoPadding)
-var RawHexEncoding = NewEncoding(encodeHex).WithPadding(NoPadding)
+var RawStdEncoding = NewEncodingCI(encodeStd).WithPadding(NoPadding)
+var RawHexEncoding = NewEncodingCI(encodeHex).WithPadding(NoPadding)
 
 /*
  * Encoder

--- a/base32_test.go
+++ b/base32_test.go
@@ -17,7 +17,7 @@ type testpair struct {
 	decoded, encoded string
 }
 
-var pairs = []testpair{
+var pairsUpper = []testpair{
 	// RFC 4648 examples
 	{"", ""},
 	{"f", "MY======"},
@@ -38,6 +38,15 @@ var pairs = []testpair{
 	{"sure.", "ON2XEZJO"},
 }
 
+var pairs = pairsUpper
+
+func init() {
+	// also test lower case versions
+	for _, p := range pairsUpper {
+		pairs = append(pairs, testpair{p.decoded, strings.ToLower(p.encoded)})
+	}
+}
+
 var bigtest = testpair{
 	"Twas brillig, and the slithy toves",
 	"KR3WC4ZAMJZGS3DMNFTSYIDBNZSCA5DIMUQHG3DJORUHSIDUN53GK4Y=",
@@ -52,14 +61,14 @@ func testEqual(t *testing.T, msg string, args ...interface{}) bool {
 }
 
 func TestEncode(t *testing.T) {
-	for _, p := range pairs {
+	for _, p := range pairsUpper {
 		got := StdEncoding.EncodeToString([]byte(p.decoded))
 		testEqual(t, "Encode(%q) = %q, want %q", p.decoded, got, p.encoded)
 	}
 }
 
 func TestEncoder(t *testing.T) {
-	for _, p := range pairs {
+	for _, p := range pairsUpper {
 		bb := &bytes.Buffer{}
 		encoder := NewEncoder(StdEncoding, bb)
 		encoder.Write([]byte(p.decoded))
@@ -145,7 +154,7 @@ func TestDecodeCorrupt(t *testing.T) {
 	}{
 		{"", -1},
 		{"!!!!", 0},
-		{"x===", 0},
+		{"!===", 0},
 		{"AA=A====", 2},
 		{"AAA=AAAA", 3},
 		{"MMMMMMMMM", 8},
@@ -353,3 +362,4 @@ func TestNoPaddingRand(t *testing.T) {
 		}
 	}
 }
+


### PR DESCRIPTION
This will fix https://github.com/multiformats/go-multibase/issues/16.