### PR TITLE
gx: release 0.0.2

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.0.1: QmZvZSVtvxak4dcTkhsQhqd1SQ6rg5UzaSTu62WfWKjj93
+0.0.2: QmfVj3x4D6Jkq9SEoi5n2NmoUomLwoeiwnYz2KQa15wRw6

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "language": "go",
   "license": "",
   "name": "base32",
-  "version": "0.0.1"
+  "version": "0.0.2"
 }
 


### PR DESCRIPTION
* Adds support for base-insensitive decoding.